### PR TITLE
Updated php memory_limit in unit tests

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -114,7 +114,6 @@ RUN ln -s /var/lib/vendor/bin/phan /usr/bin/phan
 # enable and configure xdebug
 RUN pecl install xdebug-3.1.4
 
-
 # temporary switch on the "allow_url_fopen" to install composer and phan
 RUN sed -i 's:^allow_url_fopen = On$:allow_url_fopen = Off:g' /etc/php.ini
 

--- a/tests/unit/PHPConfigCest.php
+++ b/tests/unit/PHPConfigCest.php
@@ -61,7 +61,7 @@ class PHPConfigCest
     public function checkPHPConfig_memory_limit(UnitTester $I){
         $I->wantTo("verify the config - memory_limit = 2048M");
         $I->runShellCommand("docker exec test_web_rhel php -r \"echo ini_get('memory_limit');\"");
-        $I->canSeeInShellOutput("2560M");
+        $I->canSeeInShellOutput("2048M");
     }
 
     public function checkPHPConfig_max_input_vars(UnitTester $I){


### PR DESCRIPTION
Changed the php memory_limit value in the unit tests from 2560M to 2048M to fix the unit test failures.